### PR TITLE
issue #885 fix dealing with EOL on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .codecov.yml export-ignore
 .editorconfig export-ignore


### PR DESCRIPTION
EOL forced to LF in .gitattributes for all text files