### PR TITLE
Update PHPDoc comment

### DIFF
--- a/src/Carbon/Carbon.php
+++ b/src/Carbon/Carbon.php
@@ -2768,7 +2768,7 @@ class Carbon extends DateTime
     }
 
     /**
-     * The number of seconds until 23:23:59.
+     * The number of seconds until 23:59:59.
      *
      * @return int
      */


### PR DESCRIPTION
"secondsUntilEndOfDay" function 's old comment is 'The number of seconds
until 23:23:59'.

It should be 'The number of seconds until 23:59:59'

Originally https://github.com/briannesbitt/Carbon/pull/947